### PR TITLE
bcs-monitor-0.29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ examples/tmp/
 
 # Ignore generated Cortex files
 internal/cortex/querier/active-query-tracker
+.vscode

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -776,11 +776,19 @@ func (er *endpointRef) SendsSortedSeries() bool {
 }
 
 func (er *endpointRef) String() string {
-	mint, maxt := er.TimeRange()
-	return fmt.Sprintf(
-		"Addr: %s LabelSets: %v Mint: %d Maxt: %d",
-		er.addr, labelpb.PromLabelSetsToString(er.LabelSets()), mint, maxt,
-	)
+	//mint, maxt := er.TimeRange()
+	//return fmt.Sprintf(
+	//	"Addr: %s LabelSets: %v Mint: %d Maxt: %d",
+	//	er.addr, labelpb.PromLabelSetsToString(er.LabelSets()), mint, maxt,
+	//)
+
+	// bcs patch, 返回太长, 需要精简
+	ls := labelpb.PromLabelSetsToString(er.LabelSets())
+	if len(ls) > 64 {
+		ls = ls[:64] + "...(truncated)"
+	}
+
+	return fmt.Sprintf("Addr: %s LabelSets: %s", er.addr, ls)
 }
 
 func (er *endpointRef) Addr() (string, bool) {

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -290,6 +290,8 @@ func (q *querier) Select(_ bool, hints *storage.SelectHints, ms ...*labels.Match
 		"matchers": "{" + strings.Join(matchers, ",") + "}",
 	})
 
+	// BCS CopyLabelMatchContext
+	ctx = store.CopyLabelMatchContext(ctx, q.ctx)
 	promise := make(chan storage.SeriesSet, 1)
 	go func() {
 		defer close(promise)

--- a/pkg/server/http/http.go
+++ b/pkg/server/http/http.go
@@ -5,6 +5,7 @@ package http
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/pprof"
 
@@ -76,6 +77,16 @@ func (s *Server) ListenAndServe() error {
 		return errors.Wrap(err, "server could not be started")
 	}
 	return errors.Wrap(toolkit_web.ListenAndServe(s.srv, s.opts.tlsConfigPath, s.logger), "serve HTTP and metrics")
+}
+
+// Serve for dualStack
+func (s *Server) Serve(l net.Listener) error {
+	level.Info(s.logger).Log("msg", "listening for requests and metrics", "address", s.opts.listen)
+	err := toolkit_web.Validate(s.opts.tlsConfigPath)
+	if err != nil {
+		return errors.Wrap(err, "server could not be started")
+	}
+	return errors.Wrap(toolkit_web.Serve(l, s.srv, s.opts.tlsConfigPath, s.logger), "serve HTTP and metrics")
 }
 
 // Shutdown gracefully shuts down the server by waiting,

--- a/pkg/store/bcs.go
+++ b/pkg/store/bcs.go
@@ -1,0 +1,237 @@
+// Copyright (c) The BCS Authors.
+// Licensed under the Apache License 2.0.
+
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// LabelMatchKey
+	LabelMatchKey           = ctxKey(1)
+	requestIDKey            = ctxKey(2)
+	scopeClusterIDHeaderKey = ctxKey(3)
+	requestIDHeaderKey      = "X-Request-ID"
+)
+
+const (
+	ScopeProjectIDHeaderKey  = "X-Scope-Project-Id"
+	ScopeProjectCodeHeadeKey = "X-Scope-Project-Code"
+	ScopeClusterIDHeaderKey  = "X-Scope-Cluster-Id"
+)
+
+// RequestIdHeaderKey :
+func RequestIdHeaderKey() string {
+	return requestIDHeaderKey
+}
+
+// CopyLabelMatchContext copies the necessary trace context from given source context to target context.
+func CopyLabelMatchContext(trgt, src context.Context) context.Context {
+	requestID := RequestIDValue(src)
+	clusterID := ClusterIDValue(src)
+	v, ok := LabelMatchValue(src)
+	if !ok {
+		return WithRequestIDValue(trgt, requestID)
+	}
+	return WithScopeClusterIDValue(WithRequestIDValue(WithLabelMatchValue(trgt, v), requestID), clusterID)
+}
+
+// CopyToGRPCValues context to grpc
+func CopyToGRPCValues(ctx context.Context) context.Context {
+	requestID := RequestIDValue(ctx)
+	clusterID := ClusterIDValue(ctx)
+	return WithScopeClusterIDValue(WithRequestIDValue(ctx, requestID), clusterID)
+}
+
+// WithLabelMatchValue 设置值
+func WithLabelMatchValue(ctx context.Context, matches [][]*labels.Matcher) context.Context {
+	return context.WithValue(ctx, LabelMatchKey, matches)
+}
+
+// WithLabelMatchValue 设置值
+func WithRequestIDValue(ctx context.Context, id string) context.Context {
+	newCtx := context.WithValue(ctx, requestIDKey, id)
+	return GRPCWithRequestIDValue(newCtx, id)
+}
+
+// WithLabelMatchValue 设置值
+func WithScopeClusterIDValue(ctx context.Context, clusterID string) context.Context {
+	newCtx := context.WithValue(ctx, scopeClusterIDHeaderKey, clusterID)
+	return GRPCWithScopeClusterIDValue(newCtx, clusterID)
+}
+
+// GRPCWithRequestIDValue : grpc 需要单独处理
+func GRPCWithRequestIDValue(ctx context.Context, id string) context.Context {
+	ctx = metadata.AppendToOutgoingContext(ctx, requestIDHeaderKey, id)
+	return ctx
+}
+
+// GRPCWithScopeClusterIDValue
+func GRPCWithScopeClusterIDValue(ctx context.Context, clusterID string) context.Context {
+	ctx = metadata.AppendToOutgoingContext(ctx, ScopeClusterIDHeaderKey, clusterID)
+	return ctx
+}
+
+// LabelMatchValue 获取值，获取变量, 修改matcher, 支持 namespace 级别过滤
+func LabelMatchValue(ctx context.Context) ([][]*labels.Matcher, bool) {
+	v, ok := ctx.Value(LabelMatchKey).([][]*labels.Matcher)
+	return v, ok
+}
+
+// RequestIDValue 获取值
+func RequestIDValue(ctx context.Context) string {
+	v, ok := ctx.Value(requestIDKey).(string)
+	if !ok || v == "" {
+		return GRPCRequestIDValue(ctx)
+	}
+
+	return v
+}
+
+// ClusterIDValue 集群ID值
+func ClusterIDValue(ctx context.Context) string {
+	v, ok := ctx.Value(scopeClusterIDHeaderKey).(string)
+	if !ok || v == "" {
+		return GRPCClusterIDValue(ctx)
+	}
+
+	return v
+}
+
+// GRPCRequestIDValue grpc 需要单独处理
+func GRPCRequestIDValue(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	values := md.Get(requestIDHeaderKey)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+// GRPCClusterIDValue
+func GRPCClusterIDValue(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	values := md.Get(ScopeClusterIDHeaderKey)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+// makeSeriesRequest
+func makeSeriesRequest(ctx context.Context, r *storepb.SeriesRequest) []*storepb.SeriesRequest {
+	matchValues, ok := LabelMatchValue(ctx)
+	if !ok || len(matchValues) == 0 {
+		return []*storepb.SeriesRequest{r}
+	}
+
+	reqs := make([]*storepb.SeriesRequest, 0, len(matchValues))
+	for _, v := range matchValues {
+		storeMatchers, _ := storepb.PromMatchersToMatchers(v...)
+		newReq := *r
+		newReq.Matchers = append(newReq.Matchers, storeMatchers...)
+		reqs = append(reqs, &newReq)
+	}
+
+	return reqs
+}
+
+// makeLabelNamesRequest
+func makeLabelNamesRequest(ctx context.Context, r *storepb.LabelNamesRequest) []*storepb.LabelNamesRequest {
+	matchValues, ok := LabelMatchValue(ctx)
+	if !ok || len(matchValues) == 0 {
+		return []*storepb.LabelNamesRequest{r}
+	}
+
+	reqs := make([]*storepb.LabelNamesRequest, 0, len(matchValues))
+	for _, v := range matchValues {
+		storeMatchers, _ := storepb.PromMatchersToMatchers(v...)
+		newReq := *r
+		newReq.Matchers = append(newReq.Matchers, storeMatchers...)
+		reqs = append(reqs, &newReq)
+	}
+
+	return reqs
+}
+
+// makeLabelValuesRequest
+func makeLabelValuesRequest(ctx context.Context, r *storepb.LabelValuesRequest) []*storepb.LabelValuesRequest {
+	matchValues, ok := LabelMatchValue(ctx)
+	if !ok || len(matchValues) == 0 {
+		return []*storepb.LabelValuesRequest{r}
+	}
+
+	reqs := make([]*storepb.LabelValuesRequest, 0, len(matchValues))
+	for _, v := range matchValues {
+		storeMatchers, _ := storepb.PromMatchersToMatchers(v...)
+		newReq := *r
+		newReq.Matchers = append(newReq.Matchers, storeMatchers...)
+		reqs = append(reqs, &newReq)
+	}
+
+	return reqs
+}
+
+// storeMatchAnyMetadata 可以匹配任意Label
+func storeMatchAnyMetadata(s Client, storeDebugMatchers [][]*labels.Matcher) (ok bool, reason string) {
+	if len(storeDebugMatchers) == 0 {
+		return true, ""
+	}
+
+	labelSets := s.LabelSets()
+	for idx, ls := range labelSets {
+		if addr, isLocalClient := s.Addr(); isLocalClient {
+			labelSets[idx] = append(ls, labels.Label{Name: "__address__", Value: addr})
+		}
+	}
+
+	for _, sm := range storeDebugMatchers {
+		if labelSetsMatchAny(sm, labelSets...) {
+			return true, ""
+		}
+	}
+
+	return false, fmt.Sprintf("%v does not match debug store metadata matchers: %v", labelSets, storeDebugMatchers)
+}
+
+// labelSetsMatchAny 满足任意
+func labelSetsMatchAny(matchers []*labels.Matcher, lset ...labels.Labels) bool {
+	if len(lset) == 0 {
+		return true
+	}
+
+	for _, ls := range lset {
+		if labelSetsMatchAll(matchers, ls) {
+			return true
+		}
+	}
+	return false
+}
+
+// labelSetsMatchAll 满足所有
+func labelSetsMatchAll(matchers []*labels.Matcher, ls labels.Labels) bool {
+	// 空值返回 false
+	if len(ls) == 0 {
+		return false
+	}
+
+	for _, m := range matchers {
+		// 值不存在或者不匹配都不符合
+		if lv := ls.Get(m.Name); lv == "" || !m.Matches(lv) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -252,6 +252,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	}
 	storeMatchers, _ := storepb.PromMatchersToMatchers(matchers...) // Error would be returned by matchesExternalLabels, so skip check.
 
+	_, gctx := errgroup.WithContext(CopyToGRPCValues(srv.Context()))
 	storeDebugMsgs := []string{}
 	r := &storepb.SeriesRequest{
 		MinTime:                 originalRequest.MinTime,
@@ -269,7 +270,7 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	stores := []Client{}
 	for _, st := range s.stores() {
 		// We might be able to skip the store if its meta information indicates it cannot have series matching our query.
-		if ok, reason := storeMatches(srv.Context(), st, originalRequest.MinTime, originalRequest.MaxTime, matchers...); !ok {
+		if ok, reason := storeMatches(gctx, st, originalRequest.MinTime, originalRequest.MaxTime, matchers...); !ok {
 			storeDebugMsgs = append(storeDebugMsgs, fmt.Sprintf("store %s filtered out: %v", st, reason))
 			continue
 		}
@@ -278,8 +279,15 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 	}
 
 	if len(stores) == 0 {
+		// This is indicates that configured StoreAPIs are not the ones end user expects.
 		err := errors.New("No StoreAPIs matched for this query")
-		level.Warn(reqLogger).Log("err", err, "stores", strings.Join(storeDebugMsgs, ";"))
+		// bcs patch, 减少日志长度
+		storesMsg := strings.Join(storeDebugMsgs, ";")
+		if len(storesMsg) > 64 {
+			storesMsg = storesMsg[:64] + "...(truncated)"
+		}
+		level.Warn(reqLogger).Log("err", err, "stores", storesMsg)
+
 		if sendErr := srv.Send(storepb.NewWarnSeriesResponse(err)); sendErr != nil {
 			level.Error(reqLogger).Log("err", sendErr)
 			return status.Error(codes.Unknown, errors.Wrap(sendErr, "send series response").Error())
@@ -348,7 +356,7 @@ func storeMatches(ctx context.Context, s Client, mint, maxt int64, matchers ...*
 		return false, fmt.Sprintf("does not have data within this time period: [%v,%v]. Store time ranges: [%v,%v]", mint, maxt, storeMinTime, storeMaxTime)
 	}
 
-	if ok, reason := storeMatchDebugMetadata(s, storeDebugMatcher); !ok {
+	if ok, reason := storeMatchAnyMetadata(s, storeDebugMatcher); !ok {
 		return false, reason
 	}
 
@@ -409,7 +417,7 @@ func (s *ProxyStore) LabelNames(ctx context.Context, r *storepb.LabelNamesReques
 		warnings       []string
 		names          [][]string
 		mtx            sync.Mutex
-		g, gctx        = errgroup.WithContext(ctx)
+		g, gctx        = errgroup.WithContext(CopyToGRPCValues(ctx))
 		storeDebugMsgs []string
 	)
 
@@ -423,32 +431,45 @@ func (s *ProxyStore) LabelNames(ctx context.Context, r *storepb.LabelNamesReques
 		}
 		storeDebugMsgs = append(storeDebugMsgs, fmt.Sprintf("Store %s queried", st))
 
-		g.Go(func() error {
-			resp, err := st.LabelNames(gctx, &storepb.LabelNamesRequest{
-				PartialResponseDisabled: r.PartialResponseDisabled,
-				Start:                   r.Start,
-				End:                     r.End,
-				Matchers:                r.Matchers,
-			})
-			if err != nil {
-				err = errors.Wrapf(err, "fetch label names from store %s", st)
-				if r.PartialResponseDisabled {
-					return err
-				}
+		// BCS
+		req := &storepb.LabelNamesRequest{
+			PartialResponseDisabled: r.PartialResponseDisabled,
+			Start:                   r.Start,
+			End:                     r.End,
+			Matchers:                r.Matchers,
+		}
 
-				mtx.Lock()
-				warnings = append(warnings, err.Error())
-				mtx.Unlock()
-				return nil
-			}
+		for _, newReq := range makeLabelNamesRequest(gctx, req) {
+			func(r *storepb.LabelNamesRequest) {
+				g.Go(func() error {
 
-			mtx.Lock()
-			warnings = append(warnings, resp.Warnings...)
-			names = append(names, resp.Names)
-			mtx.Unlock()
+					resp, err := st.LabelNames(gctx, &storepb.LabelNamesRequest{
+						PartialResponseDisabled: r.PartialResponseDisabled,
+						Start:                   r.Start,
+						End:                     r.End,
+						Matchers:                r.Matchers,
+					})
+					if err != nil {
+						err = errors.Wrapf(err, "fetch label names from store %s", st)
+						if r.PartialResponseDisabled {
+							return err
+						}
 
-			return nil
-		})
+						mtx.Lock()
+						warnings = append(warnings, err.Error())
+						mtx.Unlock()
+						return nil
+					}
+
+					mtx.Lock()
+					warnings = append(warnings, resp.Warnings...)
+					names = append(names, resp.Names)
+					mtx.Unlock()
+
+					return nil
+				})
+			}(newReq)
+		}
 	}
 
 	if err := g.Wait(); err != nil {
@@ -470,7 +491,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequ
 		warnings       []string
 		all            [][]string
 		mtx            sync.Mutex
-		g, gctx        = errgroup.WithContext(ctx)
+		g, gctx        = errgroup.WithContext(CopyToGRPCValues(ctx))
 		storeDebugMsgs []string
 		span           opentracing.Span
 	)
@@ -497,34 +518,47 @@ func (s *ProxyStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequ
 		}
 		storeDebugMsgs = append(storeDebugMsgs, fmt.Sprintf("Store %s queried", st))
 
-		g.Go(func() error {
-			resp, err := st.LabelValues(gctx, &storepb.LabelValuesRequest{
-				Label:                   r.Label,
-				PartialResponseDisabled: r.PartialResponseDisabled,
-				Start:                   r.Start,
-				End:                     r.End,
-				Matchers:                r.Matchers,
-			})
-			if err != nil {
-				msg := "fetch label values from store %s"
-				err = errors.Wrapf(err, msg, st)
-				if r.PartialResponseDisabled {
-					return err
-				}
+		// BCS
+		req := &storepb.LabelValuesRequest{
+			Label:                   r.Label,
+			PartialResponseDisabled: r.PartialResponseDisabled,
+			Start:                   r.Start,
+			End:                     r.End,
+			Matchers:                r.Matchers,
+		}
 
-				mtx.Lock()
-				warnings = append(warnings, errors.Wrapf(err, msg, st).Error())
-				mtx.Unlock()
-				return nil
-			}
+		for _, newReq := range makeLabelValuesRequest(gctx, req) {
+			func(r *storepb.LabelValuesRequest) {
+				g.Go(func() error {
+					resp, err := st.LabelValues(gctx, &storepb.LabelValuesRequest{
+						Label:                   r.Label,
+						PartialResponseDisabled: r.PartialResponseDisabled,
+						Start:                   r.Start,
+						End:                     r.End,
+						Matchers:                r.Matchers,
+					})
+					if err != nil {
+						msg := "fetch label values from store %s"
+						err = errors.Wrapf(err, msg, st)
+						if r.PartialResponseDisabled {
+							return err
+						}
 
-			mtx.Lock()
-			warnings = append(warnings, resp.Warnings...)
-			all = append(all, resp.Values)
-			mtx.Unlock()
+						mtx.Lock()
+						warnings = append(warnings, errors.Wrapf(err, msg, st).Error())
+						mtx.Unlock()
+						return nil
+					}
 
-			return nil
-		})
+					mtx.Lock()
+					warnings = append(warnings, resp.Warnings...)
+					all = append(all, resp.Values)
+					mtx.Unlock()
+
+					return nil
+				})
+			}(newReq)
+		}
 	}
 
 	if err := g.Wait(); err != nil {

--- a/pkg/ui/react-app/src/thanos/Navbar.tsx
+++ b/pkg/ui/react-app/src/thanos/Navbar.tsx
@@ -33,10 +33,10 @@ const navConfig: { [component: string]: (NavConfig | NavDropDown)[] } = {
       name: 'Status',
       children: [
         { name: 'Runtime & Build Information', uri: '/status' },
-        { name: 'Command-Line Flags', uri: '/flags' },
-        { name: 'Alerts', uri: '/alerts' },
-        { name: 'Targets', uri: '/targets' },
-        { name: 'Rules', uri: '/rules' },
+        // { name: 'Command-Line Flags', uri: '/flags' },
+        // { name: 'Alerts', uri: '/alerts' },
+        // { name: 'Targets', uri: '/targets' },
+        // { name: 'Rules', uri: '/rules' },
       ],
     },
   ],
@@ -96,7 +96,7 @@ const Navigation: FC<PathPrefixProps & NavigationProps> = ({ pathPrefix, thanosC
     <Navbar className="mb-3" dark color="dark" expand="md" fixed="top">
       <NavbarToggler onClick={toggle} className="mr-2" />
       <Link className="navbar-brand" to={`${pathPrefix}${defaultRoute}`}>
-        Thanos - {thanosComponent[0].toUpperCase()}
+        BCS-Monitor - {thanosComponent[0].toUpperCase()}
         {thanosComponent.substr(1, thanosComponent.length)}
       </Link>
       <Collapse isOpen={isOpen} navbar style={{ justifyContent: 'space-between' }}>
@@ -126,9 +126,9 @@ const Navigation: FC<PathPrefixProps & NavigationProps> = ({ pathPrefix, thanosC
               </UncontrolledDropdown>
             );
           })}
-          <NavItem>
+          {/* <NavItem>
             <NavLink href="https://thanos.io/tip/thanos/getting-started.md/">Help</NavLink>
-          </NavItem>
+          </NavItem> */}
         </Nav>
       </Collapse>
       <ThemeToggle />


### PR DESCRIPTION
1.thanos0.29按照bcs-monitor-0.26分支的修改内容进行代码修改
2.因为新版本thanos pkg/store/proxy.go方法Series seriesSet已经没有这个参数了，故不在Series方法中按照vbcs-monitor-0.26版本对BCS进行 支持 LabelMatch操作，去掉所依赖的streamSeriesSet,cancelableRespSender的代码


